### PR TITLE
Add an llms_txt_toctree_only option

### DIFF
--- a/docs/source/advanced-configuration.rst
+++ b/docs/source/advanced-configuration.rst
@@ -144,6 +144,16 @@ You can exclude specific pages from being included in the generated files:
 This is useful for excluding auto-generated pages, indexes, or content that isn't relevant for LLM consumption.
 It can also be used to reduce the size of llms-full.txt.
 
+If you want output strictly limited to pages reachable from your toctree,
+disable non-toctree collection:
+
+.. code-block:: python
+
+   llms_txt_toctree_only = True
+
+This prevents include-only or otherwise unlinked documents from being added as
+standalone entries.
+
 .. _page_level_ignore:
 
 Page-Level Ignore Metadata

--- a/docs/source/configuration-values.rst
+++ b/docs/source/configuration-values.rst
@@ -103,6 +103,16 @@ Project Configuration Values
 
    .. versionadded:: 0.2.1
 
+.. confval:: llms_txt_toctree_only
+
+   - **Type**: boolean
+   - **Default**: ``False``
+   - **Description**: Restrict output to pages reachable from the root toctree.
+     When enabled, include-only or otherwise unlinked documents are not added
+     as standalone entries.
+
+   .. versionadded:: 0.8.0
+
 .. confval:: llms_txt_code_files
 
    - **Type**: list of strings

--- a/sphinx_llms_txt/__init__.py
+++ b/sphinx_llms_txt/__init__.py
@@ -88,6 +88,7 @@ def build_finished(app: Sphinx, exception):
             "llms_txt_uri_template": app.config.llms_txt_uri_template,
             "llms_txt_title": app.config.llms_txt_title,
             "llms_txt_summary": summary,
+            "llms_txt_toctree_only": app.config.llms_txt_toctree_only,
             "llms_txt_full_file": app.config.llms_txt_full_file,
             "llms_txt_full_filename": app.config.llms_txt_full_filename,
             "llms_txt_full_max_size": app.config.llms_txt_full_max_size,
@@ -124,6 +125,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("llms_txt_directives", [], "env")
     app.add_config_value("llms_txt_title", None, "env")
     app.add_config_value("llms_txt_summary", None, "env")
+    app.add_config_value("llms_txt_toctree_only", False, "env")
     app.add_config_value("llms_txt_exclude", [], "env")
     app.add_config_value("llms_txt_code_files", [], "env")
     app.add_config_value("llms_txt_code_base_path", None, "env")

--- a/sphinx_llms_txt/collector.py
+++ b/sphinx_llms_txt/collector.py
@@ -175,7 +175,8 @@ class DocumentCollector:
         collect_from_toctree(self.master_doc)
 
         # Add any remaining documents not in the toctree (sorted)
-        if hasattr(self.env, "all_docs"):
+        toctree_only = self.config.get("llms_txt_toctree_only", False)
+        if not toctree_only and hasattr(self.env, "all_docs"):
             processed_docnames = {doc for doc, _ in page_order}
             remaining = sorted(
                 [

--- a/sphinx_llms_txt/collector.py
+++ b/sphinx_llms_txt/collector.py
@@ -114,6 +114,7 @@ class DocumentCollector:
         if not self.env or not self.master_doc:
             return []
 
+        toctree_only = self.config.get("llms_txt_toctree_only", False)
         page_order = []
         visited = set()
 
@@ -134,14 +135,13 @@ class DocumentCollector:
             # Check for toctree entries in this document
             try:
                 # Look for toctree_includes which contains the direct children
-                if (
-                    hasattr(self.env, "toctree_includes")
-                    and docname in self.env.toctree_includes
-                ):
-                    for child_docname in self.env.toctree_includes[docname]:
+                children = []
+                if hasattr(self.env, "toctree_includes"):
+                    children = self.env.toctree_includes.get(docname, [])
+                if children:
+                    for child_docname in children:
                         collect_from_toctree(child_docname)
-                # Try to use dependencies to find related documents
-                elif (
+                elif not toctree_only and (
                     hasattr(self.env, "dependencies")
                     and docname in self.env.dependencies
                 ):
@@ -154,7 +154,11 @@ class DocumentCollector:
                         ):
                             collect_from_toctree(child_docname)
                 # Fallback to titles or other available references
-                elif hasattr(self.env, "titles") and hasattr(self.env, "all_docs"):
+                elif (
+                    not toctree_only
+                    and hasattr(self.env, "titles")
+                    and hasattr(self.env, "all_docs")
+                ):
                     # Get all document names
                     all_docnames = list(self.env.all_docs.keys())
 
@@ -175,7 +179,6 @@ class DocumentCollector:
         collect_from_toctree(self.master_doc)
 
         # Add any remaining documents not in the toctree (sorted)
-        toctree_only = self.config.get("llms_txt_toctree_only", False)
         if not toctree_only and hasattr(self.env, "all_docs"):
             processed_docnames = {doc for doc, _ in page_order}
             remaining = sorted(

--- a/sphinx_llms_txt/manager.py
+++ b/sphinx_llms_txt/manager.py
@@ -378,8 +378,9 @@ class LLMSFullManager:
 
         # Add any remaining files (in alphabetical order) that aren't in the page order
         # Only skip this if we aborted early due to size limits for skip/note actions
+        toctree_only = self.config.get("llms_txt_toctree_only", False)
         size_limit_exceeded = max_lines is not None and total_line_count > max_lines
-        if not (size_limit_exceeded and should_abort_early):
+        if not toctree_only and not (size_limit_exceeded and should_abort_early):
             # Get all source files in the _sources directory using configured suffixes
             source_suffixes = self._get_source_suffixes()
             all_source_files = []

--- a/tests/test_llms_txt.py
+++ b/tests/test_llms_txt.py
@@ -167,6 +167,55 @@ def test_empty_page_order():
     assert collector.get_page_order() == []
 
 
+def test_get_page_order_excludes_non_toctree_docs_when_disabled():
+    """Test that non-toctree docs are skipped when the toggle is disabled."""
+
+    class MockEnv:
+        all_docs = {
+            "index": None,
+            "guide/page1": None,
+            "includes/snippet": None,
+        }
+        toctree_includes = {"index": ["guide/page1"], "guide/page1": []}
+
+    collector = DocumentCollector()
+    collector.set_env(MockEnv())
+    collector.set_master_doc("index")
+    collector.set_config({"llms_txt_toctree_only": True})
+
+    page_order = collector.get_page_order()
+
+    assert page_order == [
+        ("index", None),
+        ("guide/page1", None),
+    ]
+
+
+def test_get_page_order_includes_non_toctree_docs_by_default():
+    """Test that non-toctree docs are included by default."""
+
+    class MockEnv:
+        all_docs = {
+            "index": None,
+            "guide/page1": None,
+            "includes/snippet": None,
+        }
+        toctree_includes = {"index": ["guide/page1"], "guide/page1": []}
+
+    collector = DocumentCollector()
+    collector.set_env(MockEnv())
+    collector.set_master_doc("index")
+    collector.set_config({})
+
+    page_order = collector.get_page_order()
+
+    assert page_order == [
+        ("index", None),
+        ("guide/page1", None),
+        ("includes/snippet", None),
+    ]
+
+
 def test_process_includes(tmp_path):
     """Test that include directives are processed correctly."""
     # Create a processor
@@ -790,6 +839,64 @@ def test_source_suffix_detection_priority():
         assert rst_pos < md_pos, "RST content should appear before MD content"
 
 
+def test_manager_skips_remaining_source_files_when_disabled():
+    """Test that fallback source-file inclusion is disabled by config toggle."""
+    import os
+    import tempfile
+
+    from sphinx_llms_txt.manager import LLMSFullManager
+
+    class MockApp:
+        class Config:
+            html_sourcelink_suffix = ".txt"
+            source_suffix = [".rst"]
+
+        config = Config()
+
+    manager = LLMSFullManager()
+    manager.set_app(MockApp())
+    manager.set_config(
+        {
+            "llms_txt_full_filename": "test.txt",
+            "llms_txt_exclude": [],
+            "llms_txt_directives": [],
+            "llms_txt_toctree_only": True,
+            "llms_txt_file": False,
+        }
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outdir = f"{tmpdir}/build"
+        srcdir = f"{tmpdir}/source"
+        sources_dir = f"{outdir}/_sources"
+
+        os.makedirs(f"{sources_dir}/includes", exist_ok=True)
+        os.makedirs(srcdir, exist_ok=True)
+
+        with open(f"{sources_dir}/index.rst.txt", "w") as f:
+            f.write("Index content")
+        with open(f"{sources_dir}/includes/ensure.rst.txt", "w") as f:
+            f.write("Include-only content")
+
+        class MockEnv:
+            all_docs = {"index": None}
+            titles = {"index": type("TitleNode", (), {"astext": lambda: "Index"})()}
+            toctree_includes = {"index": []}
+
+        manager.set_env(MockEnv())
+        manager.set_master_doc("index")
+        manager.combine_sources(outdir, srcdir)
+
+        output_file = f"{outdir}/test.txt"
+        assert os.path.exists(output_file)
+
+        with open(output_file, "r") as f:
+            content = f.read()
+
+        assert "Index content" in content
+        assert "Include-only content" not in content
+
+
 def test_summary_default_uses_first_paragraph():
     """
     Test that summary defaults to first paragraph of root document when not configured.
@@ -825,6 +932,7 @@ def test_summary_default_uses_first_paragraph():
             llms_txt_full_filename = "llms-full.txt"
             llms_txt_full_max_size = None
             llms_txt_full_size_policy = "warn_skip"
+            llms_txt_toctree_only = False
             llms_txt_directives = []
             llms_txt_exclude = []
             llms_txt_code_files = []

--- a/tests/test_llms_txt.py
+++ b/tests/test_llms_txt.py
@@ -191,6 +191,83 @@ def test_get_page_order_excludes_non_toctree_docs_when_disabled():
     ]
 
 
+def test_get_page_order_does_not_follow_directory_heuristics():
+    """Test that only explicit toctree links are traversed."""
+
+    class MockEnv:
+        all_docs = {
+            "index": None,
+            "guide/page1": None,
+            "guide/includes/snippet": None,
+            "guide/page2": None,
+        }
+        toctree_includes = {"index": ["guide/page1"], "guide/page1": []}
+        # These attributes used to trigger heuristic traversal in collector.
+        titles = {
+            "index": None,
+            "guide/page1": None,
+            "guide/includes/snippet": None,
+            "guide/page2": None,
+        }
+        dependencies = {
+            "guide/page1": {
+                "guide/includes/snippet.rst": None,
+                "guide/page2.rst": None,
+            }
+        }
+
+    collector = DocumentCollector()
+    collector.set_env(MockEnv())
+    collector.set_master_doc("index")
+    collector.set_config({"llms_txt_toctree_only": True})
+
+    page_order = collector.get_page_order()
+
+    assert page_order == [
+        ("index", None),
+        ("guide/page1", None),
+    ]
+
+
+def test_get_page_order_follows_legacy_fallbacks_by_default():
+    """Test that legacy traversal still applies when toctree-only is disabled."""
+
+    class MockEnv:
+        all_docs = {
+            "index": None,
+            "guide/page1": None,
+            "guide/includes/snippet": None,
+            "guide/page2": None,
+        }
+        toctree_includes = {"index": ["guide/page1"], "guide/page1": []}
+        titles = {
+            "index": None,
+            "guide/page1": None,
+            "guide/includes/snippet": None,
+            "guide/page2": None,
+        }
+        dependencies = {
+            "guide/page1": {
+                "guide/includes/snippet": None,
+                "guide/page2": None,
+            }
+        }
+
+    collector = DocumentCollector()
+    collector.set_env(MockEnv())
+    collector.set_master_doc("index")
+    collector.set_config({})
+
+    page_order = collector.get_page_order()
+
+    assert page_order == [
+        ("index", None),
+        ("guide/page1", None),
+        ("guide/includes/snippet", None),
+        ("guide/page2", None),
+    ]
+
+
 def test_get_page_order_includes_non_toctree_docs_by_default():
     """Test that non-toctree docs are included by default."""
 


### PR DESCRIPTION
To do:
- [x] Figure out why it is not working as expected on a real project where I want to use it.