### PR TITLE
Allow specifying custom builders.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.7.2
+-----
+
+- Add :confval:`llms_txt_allowed_builders` to control which builders trigger the LLMS file generation.
+
 0.7.1
 -----
 

--- a/docs/source/advanced-configuration.rst
+++ b/docs/source/advanced-configuration.rst
@@ -306,7 +306,7 @@ You can specify to generate the LLMS files with builders other than the default 
 
 .. code-block:: python
 
-   llms_txt_code_base_path = [ "html", "dirname", "markdown" ]
+   llms_txt_allowed_builders = [ "html", "dirhtml", "markdown" ]
 
 .. _cmake_workflow:
 

--- a/docs/source/advanced-configuration.rst
+++ b/docs/source/advanced-configuration.rst
@@ -297,6 +297,17 @@ Your URI template can use the following variables:
    See :ref:`cmake_workflow` for an example of building both HTML and Markdown and/or reStructuredText in parallel.
    Note that ``_sources`` is still needed for ``llms-full.txt`` at this time.
 
+.. _custom_builders:
+
+Custom builders
+^^^^^^^^^^^^^^^
+
+You can specify to generate the LLMS files with builders other than the default `html` and `dirhtml` with the following variable:
+
+.. code-block:: python
+
+   llms_txt_code_base_path = [ "html", "dirname", "markdown" ]
+
 .. _cmake_workflow:
 
 CMake Workflow

--- a/docs/source/configuration-values.rst
+++ b/docs/source/configuration-values.rst
@@ -121,3 +121,12 @@ Project Configuration Values
      directory to the git root and strips that prefix from file paths.
 
    .. versionadded:: 0.4.0
+
+.. confval:: llms_txt_code_base_path
+
+   - **Type**: list of strings
+   - **Default**: ``["html", "htmldir"]`` (auto-detect from git root)
+   - **Description**: List of builders that should trigger LLMS file generation.
+
+   .. versionadded:: 0.7.2
+

--- a/docs/source/configuration-values.rst
+++ b/docs/source/configuration-values.rst
@@ -122,7 +122,7 @@ Project Configuration Values
 
    .. versionadded:: 0.4.0
 
-.. confval:: llms_txt_code_base_path
+.. confval:: llms_txt_allowed_builders
 
    - **Type**: list of strings
    - **Default**: ``["html", "htmldir"]`` (auto-detect from git root)

--- a/sphinx_llms_txt/__init__.py
+++ b/sphinx_llms_txt/__init__.py
@@ -127,11 +127,12 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("llms_txt_exclude", [], "env")
     app.add_config_value("llms_txt_code_files", [], "env")
     app.add_config_value("llms_txt_code_base_path", None, "env")
+    app.add_config_value("llms_txt_allowed_builders", ["html", "dirhtml"], "env")
 
     def builder_inited(app):
         """Used to limit what builders are allowed to run the extension."""
 
-        allowed_builders = ["html", "dirhtml"]
+        allowed_builders = app.config.llms_txt_allowed_builders
         if hasattr(app, "builder") and app.builder.name in allowed_builders:
             # Reset manager and root paragraph for each build
             global _manager, _root_first_paragraph


### PR DESCRIPTION
Closes https://github.com/jdillard/sphinx-llms-txt/issues/71

Adds an option to specify additional/different builders that trigger the generation of `llms.txt` files.